### PR TITLE
Use vim.lsp.get_clients: vim.lsp.get_active_clients is deprecated

### DIFF
--- a/lua/tw-values/init.lua
+++ b/lua/tw-values/init.lua
@@ -40,7 +40,11 @@ function M.show(bufnr)
     end
 
     local parent = cursor:parent()
-    local parent_parent = parent:parent()
+
+    if not parent then
+      print("No parent found")
+      return
+    end
 
     -- Returns multiple
     local queries = Parser.get_treesitter(bufnr)
@@ -52,7 +56,7 @@ function M.show(bufnr)
 
     local found_match = false
 
-    for index, query in ipairs(queries) do
+    for _, query in ipairs(queries) do
         if found_match then
             break
         end
@@ -89,7 +93,7 @@ function M.show(bufnr)
                             character = class.col
                         }
 
-                    }, function(err, result, ctx, config)
+                    }, function(err, result, _, _)
                         index = index + 1
 
                         if err then
@@ -106,7 +110,7 @@ function M.show(bufnr)
                                 table.insert(extracted, 1, " ")
                             end
 
-                            for i, value in ipairs(extracted) do
+                            for _, value in ipairs(extracted) do
                                 table.insert(results, #results + 1, value)
                             end
                         end
@@ -210,8 +214,6 @@ function OpenFloats(results, unkownclasses)
     local extra_buf = vim.api.nvim_create_buf(true, true)
     local new_win_title = "Unknown classes"
     local new_win_width = Utils.get_longest(unkownclasses, #new_win_title)
-
-    local win_info = vim.api.nvim_win_get_position(win)
 
     vim.api.nvim_buf_set_lines(extra_buf, 0, -1, false, unkownclasses)
 

--- a/lua/tw-values/utils.lua
+++ b/lua/tw-values/utils.lua
@@ -77,22 +77,14 @@ M.get_longest = function(t, init_len)
 end
 
 M.get_tw_client = function()
-    local clients = vim.lsp.get_active_clients()
+    local clients = vim.lsp.get_clients({name = "tailwindcss"})
 
-    local tw = nil
-
-    for _, client in pairs(clients) do
-        if client.name == "tailwindcss" then
-            tw = client
-        end
-    end
-
-    if tw == nil then
+    if not clients[1] then
         print("No tailwindcss client found")
         return
     end
 
-    return tw
+    return clients[1]
 end
 
 M.format_to_css = function(t)

--- a/lua/tw-values/utils.lua
+++ b/lua/tw-values/utils.lua
@@ -39,7 +39,7 @@ M.mysplit = function(inputstr, sep, init_col, init_row)
         end
 
         for str in string.gmatch(row, "([^" .. sep .. "]+)") do
-            local start_pos, end_pos = row:find(str, offset + 1, true)
+            local start_pos, _ = row:find(str, offset + 1, true)
             local new_col = base_col + start_pos - 1
 
             table.insert(t, {


### PR DESCRIPTION
- vim.lsp.get_active_clients is deprecated, use vim.lsp.get_clients instead
- pass in filter to get_clients
- simplify logic for checking for tailwindcss lsp
- use _ for unused variables in iterators 