### PR TITLE
feat: adds support for templ filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The currently supported languages are the following:
 - astro
 - vue
 - svelte
+- templ
 - html
 
 Uses HTML parser as fallback, which works for a lot of variants. Like htmldjango etc.

--- a/lua/tw-values/treesitter.lua
+++ b/lua/tw-values/treesitter.lua
@@ -63,6 +63,12 @@ local html_parser = function()
     }
 end
 
+local templ_parser = function()
+    return {
+        standard("templ")
+    }
+end
+
 M.parsers = {
     typescriptreact = tsx_parser,
     typescript = typescript_parser,
@@ -70,6 +76,7 @@ M.parsers = {
     vue = vue_parser,
     svelte = svelte_parser,
     html = html_parser,
+    templ = templ_parser,
 }
 
 M.get_treesitter = function(bufnr)


### PR DESCRIPTION
Should we allow a way for the user to set filetypes that can be passed into `standard` function instead of defining all these parsers manually?