### PR TITLE
feat(config) Add title as optional configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ use({ "MaximilianLloyd/tw-values.nvim" })
     },
     opts = {
         border = "rounded", -- Valid window border style,
+        title = "Tailwind CSS Values", -- Float window title
         show_unknown_classes = true, -- Shows the unknown classes popup
         focus_preview = true, -- Sets the preview as the current window
         copy_register = "", -- The register to copy values to,
@@ -65,12 +66,13 @@ use({ "MaximilianLloyd/tw-values.nvim" })
 
 ## Configuration
 
-Right now the configurtion options are quite minimal.
+Right now the configuration options are quite minimal.
 
 ```lua
 ...
 {
     border = "rounded", -- Valid window border style,
+    title = "Tailwind CSS Values", -- Float window title
     show_unknown_classes = true, -- Shows the unknown classes popup
     focus_preview = false, -- Sets the preview as the current window
     copy_register = "", -- The register to copy values to,

--- a/lua/tw-values/init.lua
+++ b/lua/tw-values/init.lua
@@ -7,6 +7,7 @@ local M = {}
 function M.defaults()
     local defaults = {
         border = "rounded",
+        title = "Tailwind CSS values",
         show_unknown_classes = true,
         focus_preview = false,
         copy_register = "",
@@ -247,7 +248,7 @@ function OpenFloats(results, unknownclasses)
     end
 
     local formatted_results = Utils.format_to_css(results)
-    local title = "Tailwind CSS values"
+    local title = M.options.title
     local longest = Utils.get_longest(formatted_results, #title)
     local height = #formatted_results
 
@@ -256,7 +257,7 @@ function OpenFloats(results, unknownclasses)
         border = M.options.border,
         width = longest,
         height = height,
-        title = "Tailwind CSS values",
+        title = title,
     })
     -- Focus buf
     -- Open a window below it


### PR DESCRIPTION
Adds a new configuration option that can change the title displayed on the floating window.

Default value is the one used now: "Tailwind CSS values"